### PR TITLE
Fix Choco Push condition to match tag refs instead of master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,6 @@ jobs:
 
       - name: Choco Push
         uses: crazy-max/ghaction-chocolatey@v1.4.0
-        if: github.ref == 'refs/heads/master'
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           args: push abaclient.$TAG.nupkg --source https://push.chocolatey.org/ --api-key ${{ secrets.CHOCO_API_KEY }} --allow-unofficial


### PR DESCRIPTION
The workflow triggers on tag pushes but the push step was gated on refs/heads/master, so it never ran. Align the condition with the trigger.