### PR TITLE
Fix Choco Push failing due to quoted nupkg filename

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,4 +40,4 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: crazy-max/ghaction-chocolatey@v1.4.0
         with:
-          args: push "abaclient.${{ env.TAG }}.nupkg" --source "https://push.chocolatey.org/" --api-key "${{ secrets.CHOCO_API_KEY }}" --allow-unofficial
+          args: push abaclient.${{ env.TAG }}.nupkg --source "https://push.chocolatey.org/" --api-key "${{ secrets.CHOCO_API_KEY }}" --allow-unofficial


### PR DESCRIPTION
Remove literal quotes around nupkg filename in Choco Push args