### PR TITLE
Add scheduled workflow to auto-release new AbaClient versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ name: Publish Chocolatey Package
 on:
   push:
     tags: [ '*' ]
+  schedule:
+    - cron: '0 6 * * 1'
   workflow_dispatch:
     inputs:
       tag:
@@ -26,23 +28,36 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
+      - name: Check for new AbaClient version
+        id: check_version
+        if: github.event_name == 'schedule'
+        run: ./scripts/check-version.sh
+
       - name: Display Version (debug)
+        if: github.event_name != 'schedule' || steps.check_version.outputs.new_version != ''
         run: echo "Trying to use version $TAG"
 
-      - name: Find and Replace Version
-        run: find . -name "*.nuspec" -type f -exec sed -i "s/#{VERSION}#/$TAG/g" {} \;
+      - name: Replace Version Tokens
+        if: github.event_name != 'schedule' || steps.check_version.outputs.new_version != ''
+        uses: DigitecGalaxus/actions/templating/replace-tokens@v4
+        with:
+          sources: |
+            *.nuspec
+            tools/chocolateyinstall.ps1
+          variables: '{"VERSION":"${{ env.TAG }}"}'
 
       - name: Choco Pack
+        if: github.event_name != 'schedule' || steps.check_version.outputs.new_version != ''
         uses: crazy-max/ghaction-chocolatey@v1.4.0
         with:
           args: pack --allow-unofficial
-          
+
       - name: Choco Push
-        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        if: (github.event_name != 'schedule' || steps.check_version.outputs.new_version != '') && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
         uses: crazy-max/ghaction-chocolatey@v1.4.0
         with:
           args: push abaclient.${{ env.TAG }}.nupkg --source "https://push.chocolatey.org/" --api-key "${{ secrets.CHOCO_API_KEY }}" --allow-unofficial

--- a/README.md
+++ b/README.md
@@ -13,37 +13,15 @@ choco upgrade abaclient
 ```
 
 ## Updating the Package
-To release a new version of the AbaClient package, follow these steps:
+A scheduled GitHub Actions workflow checks the [Abacus downloads page](https://downloads.abacus.ch/en/downloads/abaclient/) weekly. If that version isn't already published on [Chocolatey](https://community.chocolatey.org/packages/abaclient), the same workflow run packs and publishes it directly — no git tag is created.
 
-1. Update the version number in the chocolateyinstall.ps1 file. Modify the $version variable to match the new version. For example:
-```bash
-$version = '3.0.940'
-```
+`tools/chocolateyinstall.ps1` has no hardcoded version or checksums — its `#{VERSION}#` placeholder is filled in at pack time, the same way the version in `abaclient.nuspec` is.
 
-2. Update the checksums of the new installation files in the chocolateyinstall.ps1 file. Modify the $checksums variable accordingly.
-```bash
-$checksums = @{
-  en = 'a5abc89b5084a5d1bf96e3cf9d401748f062564a2421d883ca80792de761822a'
-  de = '497da4cc77207f9e349fb10f60f9d549b93657a596ee343a127e39d41ba1ad0e'
-  fr = 'abeb6369c691bb8fc014ad10815cc95a396a2f9c6c96bb154e08bb57aed4c25d'
-  it = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-}
-```
-
-3. Create a new GitHub tag that matches the new version number. For example:
+To manually release a specific version instead of waiting for the schedule, trigger the "Publish Chocolatey Package" workflow via `workflow_dispatch` with the desired tag as input, or push a git tag matching the version directly:
 ```bash
 git tag 3.0.940
+git push origin 3.0.940
 ```
-
-4. Commit your changes to the repository. Make sure you have staged all the changes you made in chocolateyinstall.ps1 and adapt the path in the git add command to the actual location of your chocolateyinstall.ps1 file:
-```bash
-git add tools/chocolateyinstall.ps1
-git commit -m "Update version to 3.0.940"
-```
-
-5. Push the committed changes and the new tag (with ``` --tags```) to the remote repository.
-
-GitHub Actions will automatically build and publish the updated package to Chocolatey based on the newly created tag.
 
 ## Contributing
 Contributions to this repository are welcome! If you find any issues or have suggestions for improvements, please feel free to open an issue or submit a pull request.

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+downloads_page_url="https://downloads.abacus.ch/en/downloads/abaclient/"
+
+latest_version=$(curl -sL -A "Mozilla/5.0" "$downloads_page_url" \
+  | grep -oE 'abaclient-[0-9]+(\.[0-9]+)*-en\.msi' \
+  | sed -E 's/abaclient-([0-9.]+)-en\.msi/\1/' \
+  | sort -V | tail -1)
+
+if [ -z "$latest_version" ]; then
+  echo "Could not find any AbaClient version on $downloads_page_url" >&2
+  exit 1
+fi
+echo "Latest version on $downloads_page_url : $latest_version"
+
+status_code=$(curl -sL -o /dev/null -w "%{http_code}" "https://community.chocolatey.org/packages/abaclient/$latest_version")
+
+if [ "$status_code" = "200" ]; then
+  echo "Version $latest_version is already released on Chocolatey, nothing to do."
+else
+  echo "Version $latest_version is not yet released on Chocolatey (status $status_code). New version available."
+  echo "new_version=$latest_version" >> "$GITHUB_OUTPUT"
+  echo "TAG=$latest_version" >> "$GITHUB_ENV"
+fi

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,23 +1,12 @@
 $ErrorActionPreference = 'Stop';
 
-$version = "4.3.1194"
+$version = "#{VERSION}#"
 $language = (Get-WinSystemLocale | select -ExpandProperty Name | % { $_.substring(0,2) }).ToLower()
 $url = "https://downloads.abacus.ch/fileadmin/ablage/dokumente/05_abaclient/abaclient-$version-$language.msi"
-
-$checksums = @{
-  en = 'D42AB865C40F8BFA7BA3432EBE09D0ED8421932003E0DC9DE4A625C8A02D2AF7'
-  de = '4485D101907A2DF83A36DF39F329CEFBD86DE0EDB62579290615A7FD55E56D60'
-  fr = '1F431A98E75DA0665EC1283D95C119E815387B231A3E4A552AF90CDCF4B59BD9'
-  it = 'FF64DFF74C517288C750602198D832076726920422C29D47708EA348ED7B271D'
-}
-
-$checksum = $checksums[$language]
 
 Install-ChocolateyPackage -packageName $env:ChocolateyPackageName `
   -fileType 'MSI' `
   -url $url `
   -softwareName "ABACUS AbaClient version $version" `
-  -checksum $checksum `
-  -checksumType 'sha256' `
   -silentArgs "/quiet /passive /norestart /l `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`"" `
   -validExitCodes= @(0, 3010, 1641)


### PR DESCRIPTION
Check the Abacus downloads page weekly against what's published on Chocolatey; pack and push automatically if a newer version exists.
Remove hardcoded version/checksums from chocolateyinstall.ps1 in favor of token replacement at pack time.